### PR TITLE
Reduce leaseTime to 1500 milliseconds

### DIFF
--- a/redisson/src/main/java/org/redisson/jcache/JCache.java
+++ b/redisson/src/main/java/org/redisson/jcache/JCache.java
@@ -97,6 +97,8 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
     private static final RedisCommand<Boolean> EVAL_PUT_IF_ABSENT = new RedisCommand<Boolean>("EVAL", new BooleanReplayConvertor(), 7, ValueType.MAP);
     private static final RedisCommand<Boolean> EVAL_REMOVE_KEY_VALUE = new RedisCommand<Boolean>("EVAL", new BooleanReplayConvertor(), 8, ValueType.MAP);
     private static final RedisCommand<Boolean> EVAL_CONTAINS_KEY = new RedisCommand<Boolean>("EVAL", new BooleanReplayConvertor(), 6, ValueType.MAP_KEY);
+
+    private static final long LEASE_TIME = 9000;
     
     private final JCacheManager cacheManager;
     private final JCacheConfiguration<K, V> config;
@@ -313,7 +315,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
 
     V load(K key) {
         RLock lock = getLock(key);
-        lock.lock(5, TimeUnit.SECONDS);
+        lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
         try {
             V value = getValueLocked(key);
             if (value == null) {
@@ -702,7 +704,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
                     try {
                         if (!containsKey(key) || replaceExistingValues) {
                             RLock lock = getLock(key);
-                            lock.lock(5, TimeUnit.SECONDS);
+                            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
                             try {
                                 if (!containsKey(key)|| replaceExistingValues) {
                                     V value;
@@ -742,7 +744,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
     private RLock getLockedLock(K key) {
         String lockName = getLockName(key);
         RLock lock = redisson.getLock(lockName);
-        lock.lock(5, TimeUnit.SECONDS);
+        lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
         return lock;
     }
 
@@ -760,7 +762,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         long startTime = currentNanoTime();
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 List<Object> result = getAndPutValueLocked(key, value);
                 if (result.isEmpty()) {
@@ -970,7 +972,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         long startTime = currentNanoTime();
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 List<Object> result = getAndPutValueLocked(key, value);
                 if (result.isEmpty()) {
@@ -1068,7 +1070,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
             long startTime = currentNanoTime();
             if (config.isWriteThrough()) {
                 RLock lock = getLock(key);
-                lock.lock(5, TimeUnit.SECONDS);
+                lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
                 
                 List<Object> result = getAndPutValue(key, value);
                 if (result.isEmpty()) {
@@ -1172,7 +1174,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         long startTime = currentNanoTime();
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 boolean result = putIfAbsentValueLocked(key, value);
                 if (result) {
@@ -1254,7 +1256,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         long startTime = System.currentTimeMillis();
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 V oldValue = getValue(key);
                 boolean result = removeValue(key);
@@ -1395,7 +1397,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         boolean result;
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 result = removeValueLocked(key, value);
                 if (result) {
@@ -1487,7 +1489,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         long startTime = currentNanoTime();
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 Object value = getAndRemoveValue(key);
                 if (value != null) {
@@ -1690,7 +1692,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         long startTime = currentNanoTime();
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 long result = replaceValueLocked(key, oldValue, newValue);
                 if (result == 1) {
@@ -1934,7 +1936,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         long startTime = currentNanoTime();
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 boolean result = replaceValueLocked(key, value);
                 if (result) {
@@ -1988,7 +1990,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         long startTime = currentNanoTime();
         if (config.isWriteThrough()) {
             RLock lock = getLock(key);
-            lock.lock(5, TimeUnit.SECONDS);
+            lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
             try {
                 V result = getAndReplaceValueLocked(key, value);
                 if (result != null) {
@@ -2046,7 +2048,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
         if (config.isWriteThrough()) {
             for (K key : keys) {
                 RLock lock = getLock(key);
-                lock.lock(5, TimeUnit.SECONDS);
+                lock.lock(LEASE_TIME, TimeUnit.MILLISECONDS);
                 V result = getAndRemoveValue(key);
                 if (result != null) {
                     deletedKeys.put(key, result);

--- a/redisson/src/main/java/org/redisson/jcache/JCache.java
+++ b/redisson/src/main/java/org/redisson/jcache/JCache.java
@@ -98,7 +98,7 @@ public class JCache<K, V> extends RedissonObject implements Cache<K, V> {
     private static final RedisCommand<Boolean> EVAL_REMOVE_KEY_VALUE = new RedisCommand<Boolean>("EVAL", new BooleanReplayConvertor(), 8, ValueType.MAP);
     private static final RedisCommand<Boolean> EVAL_CONTAINS_KEY = new RedisCommand<Boolean>("EVAL", new BooleanReplayConvertor(), 6, ValueType.MAP_KEY);
 
-    private static final long LEASE_TIME = 9000;
+    private static final long LEASE_TIME = 1500;
     
     private final JCacheManager cacheManager;
     private final JCacheConfiguration<K, V> config;


### PR DESCRIPTION
Reduces Redisson `RLock` lock lease time to 1500ms

refs https://github.com/ContaAzul/blackops/issues/1138
refs https://github.com/ContaAzul/blackops/issues/1051
@ContaAzul/blackops 